### PR TITLE
Signal an error when the http response code is not 200 OK.

### DIFF
--- a/t/trivial-download.lisp
+++ b/t/trivial-download.lisp
@@ -41,9 +41,17 @@
    (equal +readme-content+
           (uiop:read-file-string +download-pathname+))))
 
+(test (missing-file :depends-on set-up)
+  (finishes
+    (delete-file +download-pathname+))
+  (signals trivial-download:http-error (trivial-download:download "http://localhost:41111/notafile"
+                                                                  +download-pathname+))
+  (is-false (probe-file +download-pathname+)))
+
 (test (tear-down :depends-on set-up)
   (finishes
-   (delete-file +download-pathname+))
+    (when (probe-file +download-pathname+)
+      (delete-file +download-pathname+)))
   (finishes
    (clack:stop *server-handler*)))
 


### PR DESCRIPTION
trivial-download doesn't check the response code of http requests, so if you use an invalid url or get an error response you'll wind up with a file describing the error instead of the contents you were looking for.

I added a condition indicating the response code, and updated the two places that call DRAKMA:HTTP-REQUEST to use a local wrapper that returns the same values, but signals an error if the response code isn't 200.