### PR TITLE
Handle 0-size files correctly.

### DIFF
--- a/src/trivial-download.lisp
+++ b/src/trivial-download.lisp
@@ -45,11 +45,15 @@
 (defun human-file-size (size)
   "Take a file size (in bytes), return it as a human-readable string."
   (let ((pair (loop for pair in +size-symbol-map+
-                    if (>= size (car pair)) return pair)))
+                    if (or (>= size (car pair))
+                           (= (car pair) 1))
+                    return pair)))
     (format nil "~f ~A" (/ size (car pair)) (cdr pair))))
 
 (defun percentage (total-bytes current-bytes)
-  (floor (/ (* current-bytes 100) total-bytes)))
+  (if (= current-bytes 0)
+      100
+      (floor (/ (* current-bytes 100) total-bytes))))
 
 (defmacro with-download (url (file-size total-bytes-read array stream)
                          &body body)


### PR DESCRIPTION
It's unusual, but possible (and sometimes even reasonable) for servers to serve empty files. This branch provides some adjustments to make trivial-download do the right thing when the file size is 0.