### PR TITLE
Don't get a stream for HEAD requests.

### DIFF
--- a/src/trivial-download.lisp
+++ b/src/trivial-download.lisp
@@ -32,7 +32,7 @@
        (cdr
         (assoc :content-length
                (third (multiple-value-list
-                       (http-request url :want-stream t :method :head))))))
+                       (http-request url :method :head))))))
     (t () nil)))
 
 (defparameter +size-symbol-map+


### PR DESCRIPTION
The stream isn't used, and asking for it prevents the
receive buffer from draining. With a sufficiently large
number of requests, the receive buffer will fill up, the
TCP window will go to 0, and the server will stop sending
data.