### PR TITLE
Fix: sbcl style-warning unused variable

### DIFF
--- a/src/trivial-download.lisp
+++ b/src/trivial-download.lisp
@@ -65,7 +65,7 @@
           (,total-bytes-read 0)
           (,array (make-array *chunk-size* :element-type '(unsigned-byte 8)))
           (,stream (car response)))
-     (unless quiet
+     (unless ,quiet
        (format t "Downloading ~S (~A)~&" ,url (if ,file-size
                                                   (human-file-size ,file-size)
                                                   "Unknown size")))


### PR DESCRIPTION
- `Style-warning`: The variable `quiet` is defined but never used.
- Fixed by unquote-splicing variable `quiet` in macro `with-download`.